### PR TITLE
[진충열] feat : vm_try_handle_fault 및 vm_do_claim_page 기능 구현

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -49,6 +49,7 @@ struct page {
 
   /* Your implementation */
   struct hash_elem hash_elem;  // SPT의 entry
+  bool writable;               // true : write & read, false : read-only
 
   /* Per-type data are binded into the union.
    * Each function automatically detects the current union */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -156,17 +156,19 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
   struct page *page = NULL;
   /* TODO: Validate the fault */
   /* TODO: Your code goes here */
-  // PF_P = 1, 권한 위반 : 복구 불가
-  if (!not_present) {
-    return false;
-  }
+  // 잘못된 주소 접근
+  if (!addr || !is_user_vaddr(addr)) return false;
+
+  // writing read-only page (exception.c, page_fault 함수 참고)
+  if (!not_present) return false;
 
   // spt에서 가상 주소 addr이 포함된 페이지 찾기
-  // 현재는 스택 영역 따로 식별 안 함 -> 스택 성장을 위해 향후 식별 필요
+  // stack growth 미고려
   page = spt_find_page(spt, addr);
-  if (page == NULL) {
-    return false;
-  }
+  if (page == NULL) return false;
+
+  // writing read-only page (not_present page 매핑 이후 확인)
+  if (write && !page->writable) return false;
 
   return vm_do_claim_page(page);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -218,12 +218,6 @@ void vm_dealloc_page(struct page *page) {
 bool vm_claim_page(void *va UNUSED) {
   struct page *page = NULL;
   /* TODO: Fill this function */
-  struct supplemental_page_table *spt = &thread_current()->spt;
-
-  page = spt_find_page(spt, va);
-  if (page == NULL) {
-    return false;
-  }
 
   return vm_do_claim_page(page);
 }
@@ -237,8 +231,6 @@ static bool vm_do_claim_page(struct page *page) {
   page->frame = frame;
 
   /* TODO: Insert page table entry to map page's VA to frame's PA. */
-  uint64_t *pml4 = thread_current()->pml4;
-  pml4_set_page(pml4, page->va, frame->kva, page->writable);
 
   return swap_in(page, frame->kva);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -5,6 +5,8 @@
 #include "threads/malloc.h"
 #include "threads/mmu.h"
 #include "threads/vaddr.h"
+#include "vm/anon.h"
+#include "vm/file.h"
 #include "vm/inspect.h"
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
@@ -45,17 +47,50 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
                                     bool writable, vm_initializer *init,
                                     void *aux) {
   ASSERT(VM_TYPE(type) != VM_UNINIT)
+  ASSERT(pg_ofs(upage) == 0);  // upage의 psize aligned 여부 확인
 
   struct supplemental_page_table *spt = &thread_current()->spt;
+  bool (*initializer)(struct page *, enum vm_type, void *);
+
+  // 해당 페이지가 존재하면
+  if (spt_find_page(spt, upage) != NULL) return false;
 
   /* Check wheter the upage is already occupied or not. */
   if (spt_find_page(spt, upage) == NULL) {
     /* TODO: Create the page, fetch the initialier according to the VM type,
      * TODO: and then create "uninit" page struct by calling uninit_new. You
      * TODO: should modify the field after calling the uninit_new. */
+    struct page *page = malloc(sizeof(struct page));
+    if (page == NULL) return false;
+
+    switch (VM_TYPE(type)) {
+      case VM_ANON:
+        initializer = anon_initializer;
+        break;
+      case VM_FILE:
+        initializer = file_backed_initializer;
+        break;
+      // case VM_PAGE_CACHE: /* for project 4 */
+      default:
+        free(page);
+        goto err;
+    }
+
+    // page 초기화
+    uninit_new(page, upage, init, type, aux, initializer);
+
+    // page.writable 초기화
+    page->writable = writable;
 
     /* TODO: Insert the page into the spt. */
+    if (!spt_insert_page(spt, page)) {
+      // destroy(page); /* free page, 타입별 destroy 함수 구현 필요 */
+      free(page);
+      goto err;
+    }
+    return true;
   }
+
 err:
   return false;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -84,8 +84,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
 
     /* TODO: Insert the page into the spt. */
     if (!spt_insert_page(spt, page)) {
-      // destroy(page); /* free page, 타입별 destroy 함수 구현 필요 */
-      free(page);
+      vm_dealloc_page(page);
       goto err;
     }
     return true;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,7 +3,6 @@
 #include "vm/vm.h"
 
 #include "threads/malloc.h"
-#include "threads/mmu.h"
 #include "threads/vaddr.h"
 #include "vm/anon.h"
 #include "vm/file.h"


### PR DESCRIPTION
- vm_try_handle_fault 기능 구현
    - 잘못된 주소(NULL, 커널 가상 주소) 접근 시 false 반환
    - 읽기 전용 페이지에서 쓰기 시도 시 false 반환
        - 유효한 페이지에서 page fault가 난 경우
        - 유효하지 않은 페이지를 spt에서 확인 후 매핑한 이후
    - spt에 존재하지 않는 페이지의 경우 false 반환
    - vm_do_clame_page 호출하여 페이지 할당

- page 구조체에 `wirtable` 멤버 변수 추가
    - true : 쓰기/읽기 전용
    - false : 읽기 전용

- vm_alloc_page_with_initializer 기초 구현