### PR TITLE
[진충열] feat: supplemental_page_table_kill 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -141,6 +141,8 @@ bool spt_insert_page(struct supplemental_page_table *spt, struct page *page) {
 }
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
+  ASSERT(spt && page);
+  hash_delete(&spt->page_map, &page->hash_elem);
   vm_dealloc_page(page);
   return true;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -274,8 +274,17 @@ void supplemental_page_table_init(struct supplemental_page_table *spt) {
 bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
                                   struct supplemental_page_table *src UNUSED) {}
 
+void hash_action_destroy(struct hash_elem *e, void *aux UNUSED) {
+  ASSERT(e != NULL);
+  struct page *page = hash_entry(e, struct page, hash_elem);
+  ASSERT(page != NULL);
+  vm_dealloc_page(page);
+}
+
 /* Free the resource hold by the supplemental page table */
 void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
   /* TODO: Destroy all the supplemental_page_table hold by thread and
    * TODO: writeback all the modified contents to the storage. */
+  ASSERT(spt);
+  hash_clear(&spt->page_map, hash_action_destroy);
 }


### PR DESCRIPTION
- `supplemental_page_table_kill` 구현
    - spt 재사용을 위해서 `hash_destroy` 대신 `hash_clear` 함수 호출
- `hash_action_destroy` 함수 구현
    - `hash_clear` 함수 인자로 사용할 `hash_action_func` 타입의 함수 구현
    - `vm_dealloc_page` 호출해서 페이지 자원 해제
- `spt_remove_page` 함수 fix
    - `hash_delete` 호출해서 해시 테이블(`page_map`)에서 제거하는 과정 추가 구현
    - 예외처리 추가