### PR TITLE
[김형일] feat(vm.c): supplemental_page_table_copy 함수 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -91,7 +91,11 @@ struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
 /* Insert PAGE into spt with validation. */
 bool spt_insert_page(struct supplemental_page_table *spt, struct page *page) {
   ASSERT(spt != NULL);
+  ASSERT(page != NULL);
   ASSERT(pg_ofs(page->va) == 0);  // va가 page aligned인지 확인
+
+  // 같은 주소에 대해 중복 삽입이 발생하는 상황에 현재는 조용한 실패. ASSERT가
+  // 필요한가?
 
   bool succ = false;
   struct hash_elem *prev = hash_insert(&spt->page_map, &page->hash_elem);


### PR DESCRIPTION
## 구현 내용

`supplemental_page_table_copy()` 구현:
1. dst SPT 초기화
2. src SPT 순회
3. UNINIT (type=VM_ANON, lazy 등록만 된 페이지)
    - 부모가 `vm_alloc_page_with_initializer(VM_ANON, va, writable, lazy_load_segment, aux)`로 등록해둔 상태
    - 자식에도 동일한 UNINIT 엔트리를 등록 
    - `aux`는 깊은 복사
    - 자식에서 `vm_alloc_page_with_initializer(VM_ANON, va, writable, lazy_load_segment, aux2)` 호출
      → 자식 SPT에 UNINIT 등록 (claim은 하지 않음)
      - 실패 시 즉시 정리 후 `false` 리턴
4. ANON & 이미 적재됨(프레임 보유, 매핑됨)
    - 자식에 동일 VA로 ANON 페이지를 새로 만들고 즉시 적재
      - `vm_alloc_page_with_initializer(VM_ANON, va, writable, /*init=*/NULL, /*aux=*/NULL)`
      - `vm_claim_page(va)`로 프레임 확보(자식 측에서 zero-fill 될 것)
    - 내용 복제:
      - 부모 KVA: `src_kva = p->frame->kva`
      - 자식 KVA: `dst_kva = spt_find_page(dst, va)->frame->kva`
      - `memcpy(dst_kva, src_kva, PGSIZE)`;
    - (지금은 swap/evict 미구현이므로 “프레임 없음(스왑 아웃)” 케이스는 고려 밖)
5. 실패 시 롤백
    - 중간에 하나라도 실패하면, 지금까지 dst에 삽입·클레임한 것들 해제/삭제 후 `false` 반환
    - 전부 성공하면 `true`