### PR TITLE
[백준렬] fix: read, copy_in 함수 수정

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -52,7 +52,7 @@ int dup2(int oldfd, int newfd);
 
 void syscall_init(void) {
   write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48 | ((uint64_t)SEL_KCSEG)
-                      << 32);
+                                                               << 32);
   write_msr(MSR_LSTAR, (uint64_t)syscall_entry);
   write_msr(MSR_SYSCALL_MASK,
             FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
@@ -288,42 +288,44 @@ int write(int fd, const void* buffer, unsigned size) {
 
 int read(int fd, void* buffer, unsigned size) {
   if (!fd || fd < 0 || fd >= FDT_SIZE) return -1;
-  int bytes_read = 0;
+
   struct thread* curr = thread_current();
   struct file* file = curr->fdt[fd];
 
   if (file == NULL || file == STDOUT_MARKER) return -1;
 
-  if (file == STDIN_MARKER) {
-    // stdin에서 읽기 전에 버퍼 유효성 검사
-    for (unsigned i = 0; i < size; i++) {
-      if (!is_user_vaddr((uint8_t*)buffer + i)) {
-        exit(-1);
-      }
-      if (!pml4_get_page(thread_current()->pml4, (uint8_t*)buffer + i)) {
+  // 버퍼 유효성 검증
+  // 1차: 빠른 유저 영역 체크
+  if (!is_user_vaddr(buffer) || !is_user_vaddr((uint8_t*)buffer + size - 1)) {
+    exit(-1);
+  }
+
+  // 2차: SPT에서 실제 매핑 확인
+  void* start_page = pg_round_down(buffer);
+  void* end_page = pg_round_down((uint8_t*)buffer + size - 1);
+
+  for (void* page = start_page; page <= end_page; page += PGSIZE) {
+    struct page* p = spt_find_page(&curr->spt, page);
+    if (p == NULL) {
+      exit(-1);
+    }
+
+    // 아직 메모리에 없으면 claim
+    if (p->frame == NULL) {
+      if (!vm_claim_page(page)) {
         exit(-1);
       }
     }
+  }
 
-    // stdin에서 읽기
+  int bytes_read = 0;
+
+  if (file == STDIN_MARKER) {
     for (unsigned i = 0; i < size; i++) {
       *((uint8_t*)buffer + i) = (uint8_t)input_getc();
     }
     bytes_read = size;
   } else {
-    // 잘못된 fd인 경우 리턴
-
-    // 버퍼가 유효한 사용자 주소인지 확인
-    for (unsigned i = 0; i < size; i++) {
-      if (!is_user_vaddr((uint8_t*)buffer + i)) {
-        exit(-1);
-      }
-      if (!pml4_get_page(thread_current()->pml4, (uint8_t*)buffer + i)) {
-        exit(-1);
-      }
-    }
-
-    // file_read() 함수 호출
     bytes_read = file_read(file, buffer, size);
   }
 
@@ -410,20 +412,33 @@ int exec(const char* cmd_line) {
 /* 유저 포인터 `usrc`로부터 size 바이트를 커널 버퍼 `dst`로 복사한다.
    성공하면 true, 실패하면 false를 반환한다. */
 bool copy_in(void* dst, const void* usrc, size_t size) {
-  for (size_t i = 0; i < size; i++) {
-    const void* user_addr = (const char*)usrc + i;
+  const char* src = (const char*)usrc;
 
-    if (!is_user_vaddr(user_addr)) {
-      return false;
-    }
-
-    void* kva = pml4_get_page(thread_current()->pml4, user_addr);
-    if (kva == NULL) {
-      return false;
-    }
-
-    ((char*)dst)[i] = *(char*)kva;
+  // 1차: 유저 영역 체크
+  if (!is_user_vaddr(src) || !is_user_vaddr(src + size - 1)) {
+    return false;
   }
+
+  // 2차: SPT 체크 + 필요시 페이지 claim
+  void* start_page = pg_round_down(src);  // 페이지의 시작 주소를 리턴
+  void* end_page = pg_round_down(src + size - 1);
+
+  for (void* page = start_page; page <= end_page; page += PGSIZE) {
+    struct page* p = spt_find_page(&thread_current()->spt, page);
+    if (p == NULL) {
+      return false;
+    }
+
+    // 아직 메모리에 없으면 claim
+    if (p->frame == NULL) {
+      if (!vm_claim_page(page)) {
+        return false;
+      }
+    }
+  }
+
+  // 복사
+  memcpy(dst, src, size);
   return true;
 }
 
@@ -440,7 +455,7 @@ bool copy_in(void* dst, const void* usrc, size_t size) {
 bool copy_in_string(char* dst, const char* us, size_t dst_sz, size_t* out_len) {
   /* (1) 파라미터 가드 */
   if (dst == NULL || dst_sz == 0) return false;
-  if (us == NULL || !is_user_vaddr(us)) exit(-1); // bad ptr → 종료
+  if (us == NULL || !is_user_vaddr(us)) exit(-1);  // bad ptr → 종료
 
   struct thread* curr = thread_current();
   void* pml4 = curr->pml4;
@@ -449,16 +464,16 @@ bool copy_in_string(char* dst, const char* us, size_t dst_sz, size_t* out_len) {
   for (size_t i = 0; i < dst_sz; i++) {
     const char* up = (const char*)us + i;
 
-    if (!is_user_vaddr(up)) exit(-1); // 커널 경계 넘어가면 종료
+    if (!is_user_vaddr(up)) exit(-1);  // 커널 경계 넘어가면 종료
     char* kva = pml4_get_page(pml4, up);
-    if (kva == NULL) exit(-1); // 미매핑 → 종료
+    if (kva == NULL) exit(-1);  // 미매핑 → 종료
 
-    char c = *kva; // 안전한 한 바이트 로드
-    dst[i] = c;    // 커널 버퍼에 기록
+    char c = *kva;  // 안전한 한 바이트 로드
+    dst[i] = c;     // 커널 버퍼에 기록
 
     if (c == '\0') {
       // 문자열 끝
-      if (out_len) *out_len = i; // 널 전까지 길이
+      if (out_len) *out_len = i;  // 널 전까지 길이
       return true;
     }
   }
@@ -476,7 +491,7 @@ pid_t fork(const char* thread_name, struct intr_frame* if_) {
 
   // 2. 전체 문자열 유효성 검사
   int len = 0;
-  int MAX_LEN = 16; // 최대 길이 제한(16자)
+  int MAX_LEN = 16;  // 최대 길이 제한(16자)
   while (len < MAX_LEN) {
     if (!is_user_vaddr(thread_name + len) ||
         !pml4_get_page(thread_current()->pml4, thread_name + len)) {
@@ -497,7 +512,6 @@ int wait(pid_t pid) { return process_wait(pid); }
 int dup2(int oldfd, int newfd) {
   if (oldfd < 0 || oldfd >= FDT_SIZE) return -1;
   if (newfd < 0 || newfd >= FDT_SIZE) return -1;
-
 
   if (oldfd == newfd) return newfd;
   struct thread* curr = thread_current();


### PR DESCRIPTION
[백준렬] fix: read, copy_in 함수 수정

기존: `pml4_get_page` 함수로 유저 포인터 검증
-> `spt_find_page` 를 통해 포인터 검증하는 것으로 변경
-> 페이지가 메모리에 있는지 확인하고 없으면 `vm_claim_page` 함수 호출